### PR TITLE
Update expectations for welcome message

### DIFF
--- a/DatingApp-SPA/e2e/src/app.e2e-spec.ts
+++ b/DatingApp-SPA/e2e/src/app.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('workspace-project App', () => {
 
   it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to DatingApp-SPA!');
+    expect(page.getTitleText()).toEqual('Dating App');
   });
 
   afterEach(async () => {

--- a/DatingApp-SPA/src/app/app.component.spec.ts
+++ b/DatingApp-SPA/src/app/app.component.spec.ts
@@ -30,6 +30,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to DatingApp-SPA!');
+    expect(compiled.querySelector('h1').textContent).toContain('Dating App');
   });
 });


### PR DESCRIPTION
## Summary
- expect `Dating App` instead of the Angular CLI default in unit and e2e tests

## Testing
- `npm test -- --no-watch --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f8c2a688832881ce6f0cca72897f