### PR TITLE
Add HttpClient test for ValueComponent

### DIFF
--- a/DatingApp-SPA/src/app/value/value.component.spec.ts
+++ b/DatingApp-SPA/src/app/value/value.component.spec.ts
@@ -2,15 +2,18 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { ValueComponent } from './value.component';
 
 describe('ValueComponent', () => {
   let component: ValueComponent;
   let fixture: ComponentFixture<ValueComponent>;
+  let httpMock: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       declarations: [ ValueComponent ]
     })
     .compileComponents();
@@ -19,10 +22,27 @@ describe('ValueComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ValueComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fetch values when getValues is called', () => {
+    const mockValues = ['val1', 'val2'];
+
+    component.getValues();
+
+    const req = httpMock.expectOne('http://localhost:5000/api/values');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockValues);
+
+    expect(component.values).toEqual(mockValues);
   });
 });


### PR DESCRIPTION
## Summary
- use `HttpClientTestingModule` and `HttpTestingController` in `ValueComponent` tests
- verify GET request and values assignment when calling `getValues`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420592393883289535dc755abe6740